### PR TITLE
Adds configurability through pillar.

### DIFF
--- a/elasticsearch/init.sls
+++ b/elasticsearch/init.sls
@@ -1,31 +1,50 @@
 # Elastic Search SALT State File
 #
 
+{%- from 'elasticsearch/settings.sls' import elasticsearch with context %}
+
 include:
   - sun-java
   - sun-java.env
 
+{%- if elasticsearch.from_pkg_repo %}
 elastic-repo:
   pkgrepo.managed:
     - humanname: elasticsearch
-    - baseurl: http://packages.elastic.co/elasticsearch/1.6/centos 
+    - baseurl: {{ elasticsearch.pkg_repo_url }}
     - gpgcheck: 0
 
 elastic-install:
   pkg.installed:
     - name: elasticsearch
-  require:
-    - pkgrepo: elastic-repo
+    - require:
+      - pkgrepo: elastic-repo
+{%- else %}
+elastic-install:
+  pkg.installed:
+    - version: {{ elasticsearch.version }}
+    - sources:
+      - elasticsearch: {{ elasticsearch.single_pkg_url }}
+{%- endif %}
+
+# Required for services command environment reset
+elastic-service-environment:
+  file.append:
+    - name: /etc/sysconfig/elasticsearch
+    - text: JAVA_HOME=/usr/lib/java
+    - require:
+      - pkg: elastic-install
 
 elastic-start:
   service.running:
     - name: elasticsearch
-  require:
-    - pkg: elastic-install
+    - require:
+      - pkg: elastic-install
+      - file: elastic-service-environment
+      - sls: sun-java.env
 
 elastic-enable:
   service.enabled:
     - name: elasticsearch
-  require:
-    - pkg: elastic-install
-
+    - require:
+      - pkg: elastic-install

--- a/elasticsearch/settings.sls
+++ b/elasticsearch/settings.sls
@@ -1,0 +1,17 @@
+{%- set p  = salt['pillar.get']('elasticsearch', {}) %}
+{%- set pc = p.get('config', {}) %}
+{%- set g  = salt['grains.get']('elasticsearch', {}) %}
+{%- set gc = g.get('config', {}) %}
+
+{%- set from_pkg_repo  = p.get('from_pkg_repo', true) %}
+{%- set version        = p.get('version', '') %}
+{%- set pkg_repo_url   = p.get('pkg_repo_url', 'http://packages.elastic.co/elasticsearch/1.6/centos') %}
+{%- set single_pkg_url = p.get('single_pkg_url', '') %}
+
+{%- set elasticsearch = {} %}
+{%- do elasticsearch.update({
+                        'from_pkg_repo'  : from_pkg_repo,
+                        'version'        : version,
+                        'pkg_repo_url'   : pkg_repo_url,
+                        'single_pkg_url' : single_pkg_url
+                      }) %}

--- a/pillar.example
+++ b/pillar.example
@@ -1,0 +1,5 @@
+elasticsearch:
+  from_pkg_repo: true
+  version: '1.4.4'
+  pkg_repo_url: 'http://packages.elastic.co/elasticsearch/1.6/centos'
+  single_pkg_url: 'https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.4.4.noarch.rpm'


### PR DESCRIPTION
Went ahead and added some configurability, including an alternate method of pulling in the package to access a specific version.

I also added the "elastic-service-environment" state to add the JAVA_HOME value.  I was getting errors trying to run the elasticsearch service because the services process ignores most environment variables.